### PR TITLE
feat: improves team map application handling

### DIFF
--- a/format.go
+++ b/format.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 )
 
-func formatUsers(users []User) string {
+func formatOwners(owners []Owner) string {
 	var output string
-	for i, user := range users {
-		output += user.Name
-		if i < len(users)-1 {
+	for i, owner := range owners {
+		output += owner.Name
+		if i < len(owners)-1 {
 			output += " "
 		} else {
 			output += ""
@@ -48,10 +48,10 @@ func FormatCSTAsCodeOwners(lines []CodeOwnersLine) (string, error) {
 		switch line.Type {
 		case "ignorable-comment":
 		case "rule":
-			output += line.RulePattern + line.Spaces + formatUsers(line.Users) + formatInlineComment(line.InlineComment) + "\n"
+			output += line.RulePattern + line.Spaces + formatOwners(line.Owners) + formatInlineComment(line.InlineComment) + "\n"
 		case "section-heading":
-			if line.Users != nil {
-				output += formatOptional(line.SectionOptional) + "[" + line.SectionName + "]" + formatMinApprovers(line.SectionMinApprovers) + line.Spaces + formatUsers(line.Users) + formatInlineComment(line.InlineComment) + "\n"
+			if line.Owners != nil {
+				output += formatOptional(line.SectionOptional) + "[" + line.SectionName + "]" + formatMinApprovers(line.SectionMinApprovers) + line.Spaces + formatOwners(line.Owners) + formatInlineComment(line.InlineComment) + "\n"
 			} else {
 				output += line.Raw + "\n"
 			}

--- a/format_test.go
+++ b/format_test.go
@@ -24,7 +24,7 @@ func TestFormatCST(t *testing.T) {
 				LineNo:      3,
 				Raw:         "*   @owner",
 				RulePattern: "*",
-				Users: []User{
+				Owners: []Owner{
 					{Type: "user-or-team", Name: "@owner"},
 				},
 				InlineComment: "",
@@ -47,7 +47,7 @@ func TestFormatCST(t *testing.T) {
 				LineNo:      2,
 				Raw:         "*   @owner",
 				RulePattern: "*",
-				Users: []User{
+				Owners: []Owner{
 					{Type: "user-or-team", Name: "@owner"},
 				},
 				InlineComment: "",
@@ -67,7 +67,7 @@ func TestFormatCST(t *testing.T) {
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   },
   {
@@ -80,7 +80,7 @@ func TestFormatCST(t *testing.T) {
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "   ",
-    "users": [
+    "owners": [
       {
         "type": "user-or-team",
         "name": "@owner"

--- a/parse_test.go
+++ b/parse_test.go
@@ -48,7 +48,7 @@ func TestParse(t *testing.T) {
 
 		assert.Equal(0, len(anomalies))
 	})
-	t.Run("section without users", func(t *testing.T) {
+	t.Run("section without owners", func(t *testing.T) {
 		content := `[section]`
 		codeOwnersLines, anomalies := Parse(content)
 
@@ -64,7 +64,7 @@ func TestParse(t *testing.T) {
 
 		assert.Equal(0, len(anomalies))
 	})
-	t.Run("section without users", func(t *testing.T) {
+	t.Run("section without owners", func(t *testing.T) {
 		content := `[section]`
 		codeOwnersLines, anomalies := Parse(content)
 
@@ -93,7 +93,7 @@ func TestParse(t *testing.T) {
 			SectionName:         "section",
 			SectionMinApprovers: 42,
 			Spaces:              "      ",
-			Users: []User{
+			Owners: []Owner{
 				{Name: "@user1", Type: "user-or-group"},
 				{Name: "@user2", Type: "user-or-group"},
 			},
@@ -146,7 +146,7 @@ func TestParse(t *testing.T) {
 			SectionOptional: false,
 			RulePattern:     "*",
 			Spaces:          "    ",
-			Users: []User{
+			Owners: []Owner{
 				{Name: "@user1", Type: "user-or-group"},
 				{Name: "@user2", Type: "user-or-group"},
 			},
@@ -166,7 +166,7 @@ func TestParse(t *testing.T) {
 			SectionOptional: false,
 			RulePattern:     "*",
 			Spaces:          "    ",
-			Users: []User{
+			Owners: []Owner{
 				{Name: "@user1", Type: "user-or-group"},
 				{Name: "@user2", Type: "user-or-group"},
 			},
@@ -176,7 +176,7 @@ func TestParse(t *testing.T) {
 		assert.Equal(0, len(anomalies))
 	})
 
-	t.Run("rule without users", func(t *testing.T) {
+	t.Run("rule without owners", func(t *testing.T) {
 		content := `*`
 		codeOwnersLines, anomalies := Parse(content)
 
@@ -191,7 +191,7 @@ func TestParse(t *testing.T) {
 		assert.Equal(Anomaly{LineNo: 1, Reason: "Unknown line type", Raw: "*"}, anomalies[0])
 	})
 
-	t.Run("rule with classified users", func(t *testing.T) {
+	t.Run("rule with classified owners", func(t *testing.T) {
 		content := `*    @user1 invalid invalid-too@ email@address.org`
 		codeOwnersLines, anomalies := Parse(content)
 
@@ -203,7 +203,7 @@ func TestParse(t *testing.T) {
 			SectionOptional: false,
 			RulePattern:     "*",
 			Spaces:          "    ",
-			Users: []User{
+			Owners: []Owner{
 				{Name: "@user1", Type: "user-or-group"},
 				{Name: "invalid", Type: "invalid"},
 				{Name: "invalid-too@", Type: "invalid"},
@@ -218,7 +218,7 @@ func TestParse(t *testing.T) {
 		}, anomalies)
 	})
 
-	t.Run("rule without users in the context of a section with", func(t *testing.T) {
+	t.Run("rule without owners in the context of a section with", func(t *testing.T) {
 		content := "^[section] @some_group\n*"
 		codeOwnersLines, anomalies := Parse(content)
 
@@ -231,7 +231,7 @@ func TestParse(t *testing.T) {
 			SectionName:         "section",
 			SectionMinApprovers: 0,
 			Spaces:              " ",
-			Users:               []User{{Name: "@some_group", Type: "user-or-group"}},
+			Owners:              []Owner{{Name: "@some_group", Type: "user-or-group"}},
 		}, codeOwnersLines[0])
 		assert.Equal(CodeOwnersLine{
 			Type:                "rule",
@@ -243,13 +243,13 @@ func TestParse(t *testing.T) {
 			RulePattern:         "*",
 			RuleSection:         "section",
 			Spaces:              "",
-			Users:               nil,
+			Owners:              nil,
 		}, codeOwnersLines[1])
 
 		assert.Equal(0, len(anomalies))
 	})
 
-	t.Run("rule without users in the context of a section with", func(t *testing.T) {
+	t.Run("rule without owners in the context of a section with", func(t *testing.T) {
 		content := "^[section] @some_group\n*"
 		codeOwnersLines, anomalies := Parse(content)
 
@@ -262,7 +262,7 @@ func TestParse(t *testing.T) {
 			SectionName:         "section",
 			SectionMinApprovers: 0,
 			Spaces:              " ",
-			Users:               []User{{Name: "@some_group", Type: "user-or-group"}},
+			Owners:              []Owner{{Name: "@some_group", Type: "user-or-group"}},
 		}, codeOwnersLines[0])
 		assert.Equal(CodeOwnersLine{
 			Type:                "rule",
@@ -274,13 +274,13 @@ func TestParse(t *testing.T) {
 			RulePattern:         "*",
 			RuleSection:         "section",
 			Spaces:              "",
-			Users:               nil,
+			Owners:              nil,
 		}, codeOwnersLines[1])
 
 		assert.Equal(0, len(anomalies))
 	})
 
-	t.Run("rule without users in the context of a section with valid and invalid users", func(t *testing.T) {
+	t.Run("rule without owners in the context of a section with valid and invalid owners", func(t *testing.T) {
 		content := "^[section] @some_group invalid_group @valid_group\n*"
 		codeOwnersLines, anomalies := Parse(content)
 
@@ -293,7 +293,7 @@ func TestParse(t *testing.T) {
 			SectionName:         "section",
 			SectionMinApprovers: 0,
 			Spaces:              " ",
-			Users: []User{
+			Owners: []Owner{
 				{Name: "@some_group", Type: "user-or-group"},
 				{Name: "invalid_group", Type: "invalid"},
 				{Name: "@valid_group", Type: "user-or-group"},
@@ -309,7 +309,7 @@ func TestParse(t *testing.T) {
 			RulePattern:         "*",
 			RuleSection:         "section",
 			Spaces:              "",
-			Users:               nil,
+			Owners:              nil,
 		}, codeOwnersLines[1])
 
 		assert.Equal(1, len(anomalies))
@@ -318,7 +318,7 @@ func TestParse(t *testing.T) {
 		}, anomalies)
 	})
 
-	t.Run("rule without users in the context of a section also without users", func(t *testing.T) {
+	t.Run("rule without owners in the context of a section also without owners", func(t *testing.T) {
 		content := "^[section]\n*"
 		codeOwnersLines, anomalies := Parse(content)
 
@@ -331,7 +331,7 @@ func TestParse(t *testing.T) {
 			SectionName:         "section",
 			SectionMinApprovers: 0,
 			Spaces:              "",
-			Users:               nil,
+			Owners:              nil,
 		}, codeOwnersLines[0])
 		assert.Equal(CodeOwnersLine{
 			Type:        "unknown",
@@ -346,7 +346,7 @@ func TestParse(t *testing.T) {
 		}, anomalies)
 	})
 
-	t.Run("rule without users in the context of a section without valid users", func(t *testing.T) {
+	t.Run("rule without owners in the context of a section without valid owners", func(t *testing.T) {
 		content := "^[section] invalid_user\n*"
 		codeOwnersLines, anomalies := Parse(content)
 
@@ -359,7 +359,7 @@ func TestParse(t *testing.T) {
 			SectionName:         "section",
 			SectionMinApprovers: 0,
 			Spaces:              " ",
-			Users:               []User{{Name: "invalid_user", Type: "invalid"}},
+			Owners:              []Owner{{Name: "invalid_user", Type: "invalid"}},
 		}, codeOwnersLines[0])
 		assert.Equal(CodeOwnersLine{
 			Type:        "unknown",

--- a/team_map.go
+++ b/team_map.go
@@ -3,6 +3,7 @@ package main
 import (
 	"cmp"
 	"encoding/json"
+	"fmt"
 	"slices"
 	"strings"
 )
@@ -10,31 +11,68 @@ import (
 func ParseTeamMap(teamMapString string) (map[string][]string, error) {
 	var teamMap map[string][]string
 	error := json.Unmarshal([]byte(teamMapString), &teamMap)
+	// unmarshal & strong typing already ensure the map is in the right
+	// shape. Only thing left is to check if the usernames don't accidentally
+	// contain the "@" prefix.
+	for team, members := range teamMap {
+		for i, member := range members {
+			if strings.HasPrefix(member, "@") {
+				return nil, fmt.Errorf("don't start team member names with an '@'; '%s' (team '%s', member %d)", member, team, i)
+			}
+		}
+	}
 	return teamMap, error
 }
 
+func cookOwner(ownerString string) Owner {
+	owner := ParseOwner(ownerString)
+
+	// if an owner in a team map doesn't start with an @, ParseOwner will
+	// classify it as 'invalid'. However, that's how owners should appear in
+	// team maps => chuck an '@' in front of it and call it a regular 'user-or-group'
+	if owner.Type == "invalid" {
+		owner.Type = "user-or-group"
+		owner.Name = "@" + ownerString
+	}
+
+	return owner
+}
+
+func uniqOwners(owners []Owner) []Owner {
+	var visited = map[string]bool{}
+	var returnValue []Owner
+
+	for _, owner := range owners {
+		if !visited[owner.Name] {
+			returnValue = append(returnValue, owner)
+			visited[owner.Name] = true
+		}
+	}
+	return returnValue
+}
+
 func ApplyTeamMap(codeOwnersLines []CodeOwnersLine, teamMap map[string][]string) []CodeOwnersLine {
-	transformedCodeOwnersLines := []CodeOwnersLine{}
+	transformedLines := []CodeOwnersLine{}
 
 	for _, line := range codeOwnersLines {
 		if line.Type == "rule" || line.Type == "section-heading" {
-			var newUsers []User = []User{}
-			for _, user := range line.Users {
-				if members := teamMap[strings.TrimPrefix(user.Name, "@")]; members != nil && user.Type == "user-or-group" {
+			var newOwners []Owner = []Owner{}
+			for _, owner := range line.Owners {
+				if members := teamMap[strings.TrimPrefix(owner.Name, "@")]; members != nil && owner.Type == "user-or-group" {
 					for _, member := range members {
-						newUsers = append(newUsers, User{Type: "user-or-group", Name: "@" + member})
+						newOwners = append(newOwners, cookOwner(member))
 					}
 				} else {
-					newUsers = append(newUsers, user)
+					newOwners = append(newOwners, owner)
 				}
 			}
-			slices.SortFunc(newUsers, func(a, b User) int {
+			slices.SortFunc(newOwners, func(a, b Owner) int {
 				return cmp.Compare(a.Name, b.Name)
 			})
-			line.Users = newUsers
+			line.Owners = uniqOwners(newOwners)
 		}
-		transformedCodeOwnersLines = append(transformedCodeOwnersLines, line)
+		transformedLines = append(transformedLines, line)
 	}
 
-	return transformedCodeOwnersLines
+	return transformedLines
 }

--- a/team_map_test.go
+++ b/team_map_test.go
@@ -11,18 +11,33 @@ func TestParseTeamMap(t *testing.T) {
 
 	t.Run("empty team map", func(t *testing.T) {
 		teamMapString := `{}`
-		teamMap, _ := ParseTeamMap(teamMapString)
+		teamMap, error := ParseTeamMap(teamMapString)
 
 		assert.Equal(0, len(teamMap))
+		assert.Nil(error)
 	})
 	t.Run("valid team map", func(t *testing.T) {
 		teamMapString := `{"team1": ["user1", "user2"], "team2": ["user3", "user4", "user5@somehwere.else.com"]}`
-		teamMap, _ := ParseTeamMap(teamMapString)
+		teamMap, error := ParseTeamMap(teamMapString)
 
 		assert.NotNil(teamMap)
 		assert.Equal(2, len(teamMap))
 		assert.Equal(2, len(teamMap["team1"]))
 		assert.Equal(3, len(teamMap["team2"]))
+		assert.Nil(error)
+	})
+
+	t.Run("valid team map, but one team member starts with an @", func(t *testing.T) {
+		teamMapString := `{"team1": ["user1", "@user-starts-with-at"]}`
+		teamMap, error := ParseTeamMap(teamMapString)
+		expected := "don't start team member names with an '@'; '@user-starts-with-at' (team 'team1', member 1)"
+
+		assert.Nil(teamMap)
+		assert.NotNil(error)
+		assert.Equal(
+			expected,
+			error.Error(),
+		)
 	})
 
 	t.Run("error: team map is an array", func(t *testing.T) {
@@ -34,4 +49,297 @@ func TestParseTeamMap(t *testing.T) {
 	})
 
 	// other validations might follow
+}
+
+func TestApplyTeamMap(t *testing.T) {
+	assert := assert.New(t)
+	t.Run("replaces teams in CodeOwners CSTs - rule", func(t *testing.T) {
+		codeOwners := []CodeOwnersLine{
+			{
+				Type:   "rule",
+				LineNo: 1,
+				Raw:    "* @team2 @team1 not@replaced.nl # comment with @team1",
+
+				RulePattern: "*",
+				Spaces:      " ",
+				Owners: []Owner{
+					{
+						Type: "user-or-group",
+						Name: "@team2",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@team1",
+					},
+					{
+						Type: "e-mail",
+						Name: "not@replaced.nl",
+					},
+				},
+				InlineComment: " comment with @team1",
+			},
+		}
+		teamMap := map[string][]string{
+			"team1": {"user1", "user2"},
+			"team2": {"user3", "user4", "user5@somewhere.else.com"},
+		}
+		expectedCodeOwners := []CodeOwnersLine{
+			{
+				Type:   "rule",
+				LineNo: 1,
+				Raw:    "* @team2 @team1 not@replaced.nl # comment with @team1",
+
+				RulePattern: "*",
+				Spaces:      " ",
+				Owners: []Owner{
+					{
+						Type: "user-or-group",
+						Name: "@user1",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@user2",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@user3",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@user4",
+					},
+					{
+						Type: "e-mail",
+						Name: "not@replaced.nl",
+					},
+					{
+						Type: "e-mail",
+						Name: "user5@somewhere.else.com",
+					},
+				},
+				InlineComment: " comment with @team1",
+			},
+		}
+		transformedCodeOwners := ApplyTeamMap(codeOwners, teamMap)
+
+		assert.Equal(expectedCodeOwners, transformedCodeOwners)
+	})
+
+	t.Run("replaces teams in CodeOwners CSTs & uniqs them - rule", func(t *testing.T) {
+		codeOwners := []CodeOwnersLine{
+			{
+				Type:   "rule",
+				LineNo: 1,
+				Raw:    "* @team2 @team1 not@replaced.nl # comment with @team1",
+
+				RulePattern: "*",
+				Spaces:      " ",
+				Owners: []Owner{
+					{
+						Type: "user-or-group",
+						Name: "@team2",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@team1",
+					},
+					{
+						Type: "e-mail",
+						Name: "not@replaced.nl",
+					},
+				},
+				InlineComment: " comment with @team1",
+			},
+		}
+		teamMap := map[string][]string{
+			"team1": {"user1", "user2", "not@replaced.nl"},
+			"team2": {"user3", "user4", "user2", "user1", "user5@somewhere.else.com"},
+		}
+		expectedCodeOwners := []CodeOwnersLine{
+			{
+				Type:   "rule",
+				LineNo: 1,
+				Raw:    "* @team2 @team1 not@replaced.nl # comment with @team1",
+
+				RulePattern: "*",
+				Spaces:      " ",
+				Owners: []Owner{
+					{
+						Type: "user-or-group",
+						Name: "@user1",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@user2",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@user3",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@user4",
+					},
+					{
+						Type: "e-mail",
+						Name: "not@replaced.nl",
+					},
+					{
+						Type: "e-mail",
+						Name: "user5@somewhere.else.com",
+					},
+				},
+				InlineComment: " comment with @team1",
+			},
+		}
+		transformedCodeOwners := ApplyTeamMap(codeOwners, teamMap)
+
+		assert.Equal(expectedCodeOwners, transformedCodeOwners)
+	})
+
+	t.Run("replaces teams in CodeOwners CSTs - section-heading", func(t *testing.T) {
+		codeOwners := []CodeOwnersLine{
+			{
+				Type:   "section-heading",
+				LineNo: 1,
+				Raw:    "[some_section] @team2 @team1 not@replaced.nl # comment with @team1",
+
+				SectionOptional:     false,
+				SectionName:         "some_section",
+				SectionMinApprovers: 0,
+				Spaces:              " ",
+				Owners: []Owner{
+					{
+						Type: "user-or-group",
+						Name: "@team2",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@team1",
+					},
+					{
+						Type: "user-or-group",
+						// same as before - not a typo
+						Name: "@team1",
+					},
+					{
+						Type: "e-mail",
+						Name: "not@replaced.nl",
+					},
+				},
+				InlineComment: " comment with @team1",
+			},
+		}
+		teamMap := map[string][]string{
+			"team1": {"user1", "user2"},
+			"team2": {"user3", "user4", "user5@somewhere.else.com"},
+		}
+		expectedCodeOwners := []CodeOwnersLine{
+			{
+				Type:   "section-heading",
+				LineNo: 1,
+				Raw:    "[some_section] @team2 @team1 not@replaced.nl # comment with @team1",
+
+				SectionOptional:     false,
+				SectionName:         "some_section",
+				SectionMinApprovers: 0,
+				Spaces:              " ",
+				Owners: []Owner{
+					{
+						Type: "user-or-group",
+						Name: "@user1",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@user2",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@user3",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@user4",
+					},
+					{
+						Type: "e-mail",
+						Name: "not@replaced.nl",
+					},
+					{
+						Type: "e-mail",
+						Name: "user5@somewhere.else.com",
+					},
+				},
+				InlineComment: " comment with @team1",
+			},
+		}
+		transformedCodeOwners := ApplyTeamMap(codeOwners, teamMap)
+
+		assert.Equal(expectedCodeOwners, transformedCodeOwners)
+	})
+
+	t.Run("only sorts owners when the team map is empty", func(t *testing.T) {
+		codeOwners := []CodeOwnersLine{
+			{
+				Type:   "rule",
+				LineNo: 1,
+				Raw:    "* not@replaced.nl @team2 @team3 @team1 # comment with @team1",
+
+				RulePattern: "*",
+				Spaces:      " ",
+				Owners: []Owner{
+					{
+						Type: "e-mail",
+						Name: "not@replaced.nl",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@team2",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@team3",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@team1",
+					},
+				},
+				InlineComment: " comment with @team1",
+			},
+		}
+		teamMap := map[string][]string{}
+		expectedCodeOwners := []CodeOwnersLine{
+			{
+				Type:   "rule",
+				LineNo: 1,
+				Raw:    "* not@replaced.nl @team2 @team3 @team1 # comment with @team1",
+
+				RulePattern: "*",
+				Spaces:      " ",
+				Owners: []Owner{
+					{
+						Type: "user-or-group",
+						Name: "@team1",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@team2",
+					},
+					{
+						Type: "user-or-group",
+						Name: "@team3",
+					},
+					{
+						Type: "e-mail",
+						Name: "not@replaced.nl",
+					},
+				},
+				InlineComment: " comment with @team1",
+			},
+		}
+		transformedCodeOwners := ApplyTeamMap(codeOwners, teamMap)
+
+		assert.Equal(expectedCodeOwners, transformedCodeOwners)
+	})
 }

--- a/testdata/json/comments.json
+++ b/testdata/json/comments.json
@@ -9,7 +9,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   },
   {
@@ -22,7 +22,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   },
   {
@@ -35,7 +35,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   },
   {
@@ -48,7 +48,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   }
 ]

--- a/testdata/json/empty-only.json
+++ b/testdata/json/empty-only.json
@@ -9,7 +9,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   }
 ]

--- a/testdata/json/kitchensink.json
+++ b/testdata/json/kitchensink.json
@@ -9,7 +9,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   },
   {
@@ -22,7 +22,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   },
   {
@@ -35,7 +35,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   },
   {
@@ -48,7 +48,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": " ",
-    "users": [
+    "owners": [
       {
         "type": "user-or-group",
         "name": "@vco-admins"
@@ -74,7 +74,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   },
   {
@@ -87,7 +87,7 @@
     "sectionName": "admin",
     "sectionMinApprovers": 2,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   },
   {
@@ -100,7 +100,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": " ",
-    "users": [
+    "owners": [
       {
         "type": "user-or-group",
         "name": "@vco-admins"
@@ -118,7 +118,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   },
   {
@@ -131,7 +131,7 @@
     "sectionName": "maintainer",
     "sectionMinApprovers": 3,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   },
   {
@@ -144,7 +144,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": " ",
-    "users": [
+    "owners": [
       {
         "type": "user-or-group",
         "name": "@vco-maintainers"
@@ -166,7 +166,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   },
   {
@@ -179,7 +179,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": " ",
-    "users": [
+    "owners": [
       {
         "type": "user-or-group",
         "name": "@vco-contributors"
@@ -201,7 +201,7 @@
     "sectionName": "",
     "sectionMinApprovers": 0,
     "spaces": "",
-    "users": null,
+    "owners": null,
     "inlineComment": ""
   }
 ]


### PR DESCRIPTION
## Description

- verify that names of team members in the map don't start with an '@'
- ensure the lists of owners in rules & section headings are unique
- refactor: rename 'users' to 'owners' everywhere, 

## Motivation and Context

feature parity (& learning go)

## How Has This Been Tested?

- [x] green ci
- [x] additional updated automated non-regression tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/vcodeowners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/vcodeowners/blob/main/.github/CONTRIBUTING.md).
